### PR TITLE
feat: Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_dispatch: # 手動実行を許可
+  push:
+    branches: 
+      - main
+      - master # mainまたはmasterブランチへのpushで自動実行
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+          
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+            
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Build Slidev
+        run: pnpm build --base /${{ github.event.repository.name }}/
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/github-pages-setup.md
+++ b/docs/github-pages-setup.md
@@ -1,0 +1,60 @@
+# GitHub Pages セットアップガイド
+
+このプレゼンテーションをGitHub Pagesで公開する手順です。
+
+## 1. GitHub Actionsを有効化
+
+1. GitHubリポジトリの `Settings` タブを開く
+2. 左メニューから `Pages` を選択
+3. `Build and deployment` セクションで:
+   - Source: `GitHub Actions` を選択
+
+## 2. ワークフローの実行
+
+### 自動デプロイ
+- `main` または `master` ブランチへのpush時に自動的にデプロイされます
+
+### 手動デプロイ
+1. リポジトリの `Actions` タブを開く
+2. 左メニューから `Deploy to GitHub Pages` を選択
+3. `Run workflow` ボタンをクリック
+4. ブランチを選択して `Run workflow` を実行
+
+## 3. デプロイ状況の確認
+
+1. `Actions` タブでワークフローの実行状況を確認
+2. 成功すると、以下のURLでアクセス可能:
+   ```
+   https://<username>.github.io/<repository-name>/
+   ```
+
+例: `https://mozumasu.github.io/slidev-template/`
+
+## 4. トラブルシューティング
+
+### ページが表示されない場合
+- `Settings` > `Pages` で GitHub Actions が選択されているか確認
+- ワークフローが正常に完了しているか確認
+- ブラウザのキャッシュをクリアして再読み込み
+
+### ビルドエラーが発生する場合
+- `pnpm-lock.yaml` がコミットされているか確認
+- Node.js のバージョン互換性を確認
+
+## 技術詳細
+
+### ワークフローファイル
+`.github/workflows/deploy.yml` で以下の処理を実行:
+
+1. Node.js LTS版のセットアップ
+2. pnpm のセットアップとキャッシュ
+3. 依存関係のインストール
+4. Slidevのビルド（ベースパスを自動設定）
+5. GitHub Pagesへのデプロイ
+
+### ベースパス設定
+GitHub Pagesでは、サブディレクトリでホスティングされるため、ビルド時に自動的にリポジトリ名をベースパスとして設定しています。
+
+```bash
+pnpm build --base /<repository-name>/
+```


### PR DESCRIPTION
## Summary
GitHub Pagesでプレゼンテーションを自動デプロイするためのワークフローを追加

## Changes
- GitHub Actions workflow (`.github/workflows/deploy.yml`) を追加
- pnpmを使用したビルドとデプロイの自動化
- main/masterブランチへのpush時に自動デプロイ
- 手動実行も可能（workflow_dispatch）
- セットアップドキュメントを追加

## Setup Instructions
1. リポジトリの Settings > Pages を開く
2. Source を `GitHub Actions` に設定
3. main/masterブランチにマージ後、自動的にデプロイ開始

## デプロイ先URL
マージ後、以下のURLでアクセス可能になります：
`https://mozumasu.github.io/slidev-template/`

## 特徴
- 🚀 自動デプロイ（main/masterブランチへのpush時）
- 📦 pnpmキャッシュによる高速ビルド
- 🔧 手動デプロイもサポート
- 📝 詳細なセットアップドキュメント付き

## Testing
- [ ] GitHub Actionsワークフローが正常に実行される
- [ ] GitHub Pagesにデプロイされる
- [ ] デプロイされたサイトが正常に表示される