### PR TITLE
fix: Update pnpm version to 10 in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
           run_install: false
           
       - name: Get pnpm store directory


### PR DESCRIPTION
## 問題
GitHub ActionsのCIが失敗していました：
- エラー: `Ignoring not compatible lockfile`
- エラー: `Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent`

## 原因
- ローカルでpnpm v10.8.0を使用してpnpm-lock.yamlを生成
- CI環境ではpnpm v8を使用していたため、lockfileの互換性がない

## 解決策
GitHub Actionsワークフローのpnpmバージョンを8から10に更新

## 変更内容
```yaml
# Before
version: 8

# After  
version: 10
```

## テスト
- [ ] CIが正常に実行される
- [ ] pnpm installが成功する
- [ ] ビルドが正常に完了する
- [ ] GitHub Pagesへのデプロイが成功する