### PR TITLE
fix: Enable GitHub Pages automatically in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,8 @@ jobs:
         
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## 問題
GitHub ActionsのワークフローでPages設定時にエラーが発生：
```
Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions
```

## 原因
GitHub Pagesが事前に有効化されていない場合、`actions/configure-pages`がエラーになる

## 解決策
`configure-pages`アクションに`enablement: true`パラメータを追加して、GitHub Pagesを自動的に有効化

## 変更内容
```yaml
- name: Setup Pages
  uses: actions/configure-pages@v4
  with:
    enablement: true  # 追加: GitHub Pagesを自動的に有効化
```

## 影響
- GitHub Pagesが未設定でもワークフローが成功する
- 手動でSettings > Pagesを設定する必要がなくなる
- 初回デプロイがよりスムーズに

## テスト
- [ ] ワークフローが正常に実行される
- [ ] GitHub Pagesが自動的に有効化される
- [ ] デプロイが成功する