### PR TITLE
fix: GitHub Pages でプロファイル画像が表示されない問題を修正

### DIFF
--- a/slidev-theme-neon/components/SelfIntroduction.vue
+++ b/slidev-theme-neon/components/SelfIntroduction.vue
@@ -28,8 +28,17 @@ const profile = {
   achievement: "Software Design 6月号にweztermの記事を寄稿しました",
 };
 
-// Profile image path
-const profileImage = computed(() => props.profileImage);
+// Profile image path with base path handling
+const profileImage = computed(() => {
+  const baseUrl = import.meta.env.BASE_URL || '/';
+  const imagePath = props.profileImage;
+  
+  // If the path starts with /, prepend the base URL
+  if (imagePath.startsWith('/')) {
+    return baseUrl + imagePath.slice(1);
+  }
+  return imagePath;
+});
 
 // Auto theme detection (based on current background theme)
 const detectedTheme = ref<"neon" | "ocean">("ocean");


### PR DESCRIPTION
## 概要
GitHub Pages でプロファイル画像が表示されない問題を修正しました。

## 変更内容
- `SelfIntroduction.vue` コンポーネントで `import.meta.env.BASE_URL` を使用してベースパスを考慮するように修正
- 画像パスが `/` で始まる場合、自動的にベースURLを付加するように処理を追加

## 修正前後の動作
- **修正前**: GitHub Pages (https://mozumasu.github.io/slidev-template/2) でプロファイル画像が404エラー
- **修正後**: ベースパス `/slidev-template/` を考慮して画像パスが正しく解決される

## テスト
- ローカル環境 (`pnpm dev`) で動作確認済み
- ビルド (`pnpm build`) が正常に完了することを確認済み