### PR TITLE
feat: OGP画像の自動生成機能を追加

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -16,6 +16,8 @@ info: |
 # transition: slide-left
 title: CLI資産を活かせ! Claude Codeで整えるアウトプットワークフロー
 mdc: true
+seoMeta:
+  ogImage: auto
 ---
 
 <div class="text-center">


### PR DESCRIPTION
## 概要
SlidevプロジェクトにOGP（Open Graph Protocol）画像の自動生成機能を追加しました。

## 変更内容
- `slides.md`のフロントマターに`seoMeta`設定を追加
- `ogImage: auto`により最初のスライドから自動的にOG画像を生成
- 生成された`og-image.png`をリポジトリに追加（233KB）

## 効果
- ソーシャルメディア（Twitter、Facebook、LinkedIn、Slackなど）でリンクを共有した際に、適切なプレビュー画像が表示されます
- 手動でOG画像を作成する手間が省けます
- ビルド時に自動的に最新のスライド内容が反映されます

## 確認方法
1. `pnpm build`でビルドを実行
2. `dist/index.html`に`og:image`メタタグが追加されていることを確認
3. `og-image.png`が生成されていることを確認

## スクリーンショット
最初のスライドから自動生成されたOG画像:
![OG Image](https://raw.githubusercontent.com/mozumasu/slidev-template/feature/add-ogp-image/og-image.png)