### PR TITLE
fix: GitHub ActionsでPlaywrightブラウザと依存関係をインストール

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install chromium
+        
       - name: Build Slidev
         run: pnpm build --base /${{ github.event.repository.name }}/
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,8 @@ jobs:
         run: pnpm install --frozen-lockfile
         
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install chromium
+        run: |
+          pnpm exec playwright install --with-deps
         
       - name: Build Slidev
         run: pnpm build --base /${{ github.event.repository.name }}/


### PR DESCRIPTION
## 概要
OGP画像自動生成機能のビルドエラーを修正しました。

## 問題
PR #9でOGP画像自動生成機能（`seoMeta: ogImage: auto`）を追加しましたが、GitHub Actionsでビルドが失敗していました。

### エラー内容
```
browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell
```

## 原因
SlidevのOG画像自動生成機能はPlaywrightを使用してスクリーンショットを撮影しますが：
1. GitHub ActionsランナーにPlaywrightのブラウザがインストールされていない
2. ブラウザ実行に必要なシステム依存関係が不足していた

## 修正内容
`.github/workflows/deploy.yml`を以下のように変更：
```yaml
- name: Install Playwright Browsers
  run: |
    pnpm exec playwright install --with-deps
```

### 変更点
- `chromium`のみではなく全ブラウザをインストール
- `--with-deps`オプションでシステム依存関係も含める

## 確認済み事項
✅ GitHub Actionsでビルド成功を確認（[Run #17600467338](https://github.com/mozumasu/slidev-template/actions/runs/17600467338)）
- Playwrightのインストール: 成功
- Slidevのビルド: 成功
- OG画像生成: エラーなし

※ デプロイはブランチ保護ルールにより制限されていますが、mainブランチにマージ後は正常にデプロイされます。

## 関連PR
- #9 feat: OGP画像の自動生成機能を追加