### PR TITLE
fix: OGP画像URLを絶対パスに変更してSNSプレビューを修正

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -17,7 +17,7 @@ info: |
 title: CLI資産を活かせ! Claude Codeで整えるアウトプットワークフロー
 mdc: true
 seoMeta:
-  ogImage: auto
+  ogImage: https://mozumasu.github.io/slidev-template/og-image.png
 ---
 
 <div class="text-center">


### PR DESCRIPTION
## 概要
OGP画像のURLを相対パスから絶対パスに変更し、SNSでのプレビュー表示を修正しました。

## 問題
`seoMeta: ogImage: auto`の設定では、生成されるHTMLに相対パス（`./og-image.png`）が設定されます。
これにより、Discord、Twitter、SlackなどのSNSクローラーが画像を取得できず、プレビューが表示されない問題が発生していました。

### 実際の症状
- Slackで共有した際にOGP画像が表示されない
- 他のSNSでも同様に画像プレビューが機能しない

<img width="667" height="153" alt="スクリーンショット 2025-09-10 11 24 43" src="https://github.com/user-attachments/assets/2b39a377-4be0-4978-ae79-9e05c1fdec96" />

## 修正内容
```yaml
# 変更前
seoMeta:
  ogImage: auto

# 変更後
seoMeta:
  ogImage: https://mozumasu.github.io/slidev-template/og-image.png
```

## 影響
- ✅ SNS（Discord、Twitter、Slack等）で画像プレビューが正しく表示されるようになる
- ✅ 絶対URLによりクローラーが確実に画像を取得できる
- ⚠️ URLがハードコードされるため、デプロイ先が変わる場合は手動で更新が必要

## テスト方法
1. デプロイ後、以下のツールで確認：
   - [Facebook Debugger](https://developers.facebook.com/tools/debug/)
   - [Twitter Card Validator](https://cards-dev.twitter.com/validator)
   - 実際にDiscordやSlackでURLを共有

## 関連PR
- #9 feat: OGP画像の自動生成機能を追加
- #10 fix: GitHub ActionsでPlaywrightブラウザと依存関係をインストール